### PR TITLE
Safer tables creation and deletion

### DIFF
--- a/Config/create.sql
+++ b/Config/create.sql
@@ -7,9 +7,7 @@ SET FOREIGN_KEY_CHECKS = 0;
 -- legacy_product_attribute_value
 -- ---------------------------------------------------------------------
 
-DROP TABLE IF EXISTS `legacy_product_attribute_value`;
-
-CREATE TABLE `legacy_product_attribute_value`
+CREATE TABLE IF NOT EXISTS `legacy_product_attribute_value`
 (
     `product_id` INTEGER NOT NULL,
     `attribute_av_id` INTEGER NOT NULL,
@@ -31,9 +29,7 @@ CREATE TABLE `legacy_product_attribute_value`
 -- legacy_product_attribute_value_price
 -- ---------------------------------------------------------------------
 
-DROP TABLE IF EXISTS `legacy_product_attribute_value_price`;
-
-CREATE TABLE `legacy_product_attribute_value_price`
+CREATE TABLE IF NOT EXISTS `legacy_product_attribute_value_price`
 (
     `product_id` INTEGER NOT NULL,
     `attribute_av_id` INTEGER NOT NULL,
@@ -63,9 +59,7 @@ CREATE TABLE `legacy_product_attribute_value_price`
 -- legacy_cart_item_attribute_combination
 -- ---------------------------------------------------------------------
 
-DROP TABLE IF EXISTS `legacy_cart_item_attribute_combination`;
-
-CREATE TABLE `legacy_cart_item_attribute_combination`
+CREATE TABLE IF NOT EXISTS `legacy_cart_item_attribute_combination`
 (
     `cart_item_id` INTEGER NOT NULL,
     `attribute_id` INTEGER NOT NULL,

--- a/Config/delete.sql
+++ b/Config/delete.sql
@@ -1,0 +1,11 @@
+
+# This is a fix for InnoDB in MySQL >= 4.1.x
+# It "suspends judgement" for fkey relationships until are tables are set.
+SET FOREIGN_KEY_CHECKS = 0;
+
+DROP TABLE IF EXISTS `legacy_product_attribute_value`;
+DROP TABLE IF EXISTS `legacy_product_attribute_value_price`;
+DROP TABLE IF EXISTS `legacy_cart_item_attribute_combination`;
+
+# This restores the fkey checks, after having unset them earlier
+SET FOREIGN_KEY_CHECKS = 1;

--- a/LegacyProductAttributes.php
+++ b/LegacyProductAttributes.php
@@ -12,10 +12,21 @@ class LegacyProductAttributes extends BaseModule
     const MESSAGE_DOMAIN_BO = 'legacyproductattributes.bo.default';
     const MESSAGE_DOMAIN_FO = 'legacyproductattributes.fo.default';
 
-    public function postActivation(ConnectionInterface $con = null)
+    public function preActivation(ConnectionInterface $con = null)
     {
         $database = new Database($con);
 
-        $database->insertSql(null, [__DIR__ . "/Config/thelia.sql"]);
+        $database->insertSql(null, [__DIR__ . "/Config/create.sql"]);
+    }
+
+    public function destroy(ConnectionInterface $con = null, $deleteModuleData = false)
+    {
+        if (!$deleteModuleData) {
+            return;
+        }
+
+        $database = new Database($con);
+
+        $database->insertSql(null, [__DIR__ . "/Config/delete.sql"]);
     }
 }


### PR DESCRIPTION
Fixes #1.

Create tables only if needed on module activation.
Add the option to delete module data on module removal.
