### PR TITLE
Add missing return value from preActivation

### DIFF
--- a/LegacyProductAttributes.php
+++ b/LegacyProductAttributes.php
@@ -17,6 +17,8 @@ class LegacyProductAttributes extends BaseModule
         $database = new Database($con);
 
         $database->insertSql(null, [__DIR__ . "/Config/create.sql"]);
+
+        return true;
     }
 
     public function destroy(ConnectionInterface $con = null, $deleteModuleData = false)


### PR DESCRIPTION
LegacyProductAttributes::preActivation has no return value, which prevents the module activation.
